### PR TITLE
メッセージテーブル実装

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,4 @@
-class Member < ApplicationRecord
+class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
 end

--- a/db/migrate/20190508111415_create_messages.rb
+++ b/db/migrate/20190508111415_create_messages.rb
@@ -1,0 +1,12 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+
+      t.text :body, null: false
+      t.string :image
+      t.references :group, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190508105930) do
+ActiveRecord::Schema.define(version: 20190508111415) do
 
   create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20190508105930) do
     t.datetime "updated_at",             null: false
     t.index ["group_id"], name: "index_members_on_group_id", using: :btree
     t.index ["user_id"], name: "index_members_on_user_id", using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text     "body",       limit: 65535, null: false
+    t.string   "image"
+    t.integer  "group_id",                 null: false
+    t.integer  "user_id",                  null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -43,4 +54,6 @@ ActiveRecord::Schema.define(version: 20190508105930) do
 
   add_foreign_key "members", "groups"
   add_foreign_key "members", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# WHAT
メッセージテーブルの実装
メッセージモデルの実装
合わせて、設計誤りの為メンバーモデルのvalidatesを削除

# WHY
メッセージテーブル実装の為