### PR TITLE
サイドコンテンツ更新

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :members
   has_many :messages
   validates :name, presence: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -11,4 +11,12 @@ class Group < ApplicationRecord
       'まだメッセージはありません。'
     end
   end
+
+  def show_members
+    member = ""
+    users.each do |user|
+      member += user.name + " "
+    end
+    return member
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -21,8 +21,10 @@
       .main-menu
         .main-header
           .group
-            %p.group__name testgroup
-            %p.group__member Member: testmember
+            %p.group__name
+              = @group.name
+            %p.group__member
+              = "Member : #{@group.show_members}"
           .main-header__btn-edit
             = link_to 'Edit', edit_group_path(@group), class: 'link__edit'
         .main-content

--- a/app/views/shared/_side-content.html.haml
+++ b/app/views/shared/_side-content.html.haml
@@ -4,4 +4,4 @@
       %p.side-content__group
         = group.name
       %p.side-content__message
-        メッセージはまだありません。
+        = group.show_last_message


### PR DESCRIPTION
# WHAT
サイドコンテンツの更新
・グループの最新メッセージが表示されるように修正
メインコンテンツのヘッダー部更新
・グループ名と参加メンバーが表示されるよう修正

# WHY
ChatSpace実装のため